### PR TITLE
Clean up `fuzz_function_call()`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 inst/doc
 vignettes/*.R
 vignettes/*.html
+.project
+org.eclipse.statet.r.core.prefs

--- a/.project
+++ b/.project
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>fuzzr</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.statet.r.resourceProjects.RBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.statet.docmlet.resourceProjects.WikitextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.statet.ide.resourceProjects.Statet</nature>
+		<nature>org.eclipse.statet.r.resourceProjects.R</nature>
+		<nature>org.eclipse.statet.r.resourceProjects.RPkg</nature>
+		<nature>org.eclipse.statet.docmlet.resourceProjects.Wikitext</nature>
+	</natures>
+</projectDescription>

--- a/.settings/org.eclipse.statet.r.core.prefs
+++ b/.settings/org.eclipse.statet.r.core.prefs
@@ -1,0 +1,2 @@
+build/RProject/RPkgRootFolder.path=
+eclipse.preferences.version=1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,10 +2,11 @@ Type: Package
 Package: fuzzr
 Title: Fuzz-Test R Functions
 Version: 0.2.2.9000
-Authors@R: person("Matthew", "Lincoln", email = "matthew.d.lincoln@gmail.com",
-  role = c("aut", "cre"))
-Description: Test function arguments with a wide array of inputs, and produce
-  reports summarizing messages, warnings, errors, and returned values.
+Authors@R: 
+    person("Matthew", "Lincoln", , "matthew.d.lincoln@gmail.com", role = c("aut", "cre"))
+Description: Test function arguments with a wide array of inputs, and
+    produce reports summarizing messages, warnings, errors, and returned
+    values.
 License: MIT + file LICENSE
 URL: https://github.com/mdlincoln/fuzzr
 BugReports: https://github.com/mdlincoln/fuzzr/issues
@@ -16,7 +17,10 @@ Imports:
 Suggests: 
     knitr,
     rmarkdown,
-    testthat
-VignetteBuilder: knitr
+    testthat (>= 3.0.0)
+VignetteBuilder: 
+    knitr
+Config/testthat/edition: 3
+Encoding: UTF-8
 LazyData: TRUE
-RoxygenNote: 6.0.1
+RoxygenNote: 7.3.2

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,6 +3,7 @@
 S3method(as.data.frame,fuzz_results)
 export(fuzz_call)
 export(fuzz_function)
+export(fuzz_function_call)
 export(fuzz_value)
 export(p_fuzz_function)
 export(test_all)

--- a/R/evaluators.R
+++ b/R/evaluators.R
@@ -39,7 +39,6 @@
 #' # When evaluating a function that takes ..., set check_args to FALSE
 #' fr <- fuzz_function(paste, "x", check_args = FALSE)
 fuzz_function <- function(fun, arg_name, ..., tests = test_all(), check_args = TRUE, progress = interactive()) {
-
   fuzz_asserts(fun, check_args, progress)
   attr(fun, "fun_name") <- deparse(substitute(fun))
   assertthat::assert_that(is_named_l(tests))
@@ -48,26 +47,75 @@ fuzz_function <- function(fun, arg_name, ..., tests = test_all(), check_args = T
   # keeping only those passed in as ... These will be used in the named list
   # passed to p_fuzz_function
   dots_call_names <- purrr::map_chr(as.list(match.call()), deparse)
-  .dots = list(...)
-  dots_call_names <- dots_call_names[names(.dots)]
+  if (!is.null(names(list(...)))) {
+    .dots <- list(...)
+    dots_call_names <- dots_call_names[names(.dots)]
+  } else {
+    .dots <- c(...)
+    dots_call_names <- names(.dots)
+  }
 
   # Check that arg_name is a string, and the tests passed is a named list
   assertthat::assert_that(assertthat::is.string(arg_name), is_named_l(tests))
 
   # Check that arguments passed to fun actually exist in fun
-  if (check_args)
+  if (check_args) {
     assertthat::assert_that(
       assertthat::has_args(fun, arg_name),
-      assertthat::has_args(fun, names(.dots)))
+      assertthat::has_args(fun, names(.dots))
+    )
+  }
 
   # Construct a list of arguments for p_fuzz_function, with tests assigned to
   # arg_name, and the values passed via ... saved as lists named after their
   # deparsed variable names.
   test_args <- c(
     purrr::set_names(list(tests), arg_name),
-    purrr::map2(.dots, dots_call_names, function(x, y) purrr::set_names(list(x), y)))
+    purrr::map2(.dots, dots_call_names, function(x, y) purrr::set_names(list(x), y))
+  )
 
   p_fuzz_function(fun, .l = test_args, check_args = check_args, progress = progress)
+}
+
+#' @rdname fuzz_function
+#' @param quoted_call A quoted function call. The parameters that are present
+#' in this call are fuzz tested separately using `tests`.
+#' @export
+#' @examples
+#' fr <- fuzz_function_call(quote(identity(x = 1)))
+#' knitr::kable(as.data.frame(fr))
+#'
+#' fr2 <- fuzz_function_call(quote(identical(x = TRUE, y = FALSE)))
+#' knitr::kable(as.data.frame(fr2))
+#'
+#' fr3 <- fuzz_function_call(quote(dirname(".")))
+#' knitr::kable(as.data.frame(fr3))
+#'
+#' fr4 <- fuzz_function_call(quote(dirname(path = ".")))
+#' knitr::kable(as.data.frame(fr4))
+#' @md
+fuzz_function_call <- function(quoted_call, tests = test_all(), check_args = TRUE, progress = interactive()) {
+  error <- purrr::safely(eval)(quoted_call)$error
+  if (!is.null(error)) {
+    stop("`quoted_call` could not be evaluated without errors: ", error)
+  }
+  fun <- get(as.list(quoted_call)[[1]])
+  parameters <- as.list(quoted_call)[-1]
+  arg_names <- if (!is.null(names(parameters))) {
+    names(parameters)
+  } else {
+    names(formals(fun))
+  }
+  result <- lapply(arg_names, function(arg_name) {
+    fuzz_function(
+      fun = fun, arg_name = arg_name, parameters[
+        which(arg_names != arg_name)
+      ], tests = tests, check_args = check_args,
+      progress = progress
+    )
+  })
+  result <- do.call(c, result)
+  structure(result, class = "fuzz_results")
 }
 
 #' @rdname fuzz_function
@@ -77,13 +125,13 @@ fuzz_function <- function(fun, arg_name, ..., tests = test_all(), check_args = T
 #'
 #' # Pass tests to multiple arguments via a named list
 #' test_args <- list(
-#'    data = test_df(),
-#'    subset = test_all(),
-#'    # Specify custom tests with a new named list
-#'    formula = list(all_vars = Sepal.Length ~ ., one_var = mpg ~ .))
+#'   data = test_df(),
+#'   subset = test_all(),
+#'   # Specify custom tests with a new named list
+#'   formula = list(all_vars = Sepal.Length ~ ., one_var = mpg ~ .)
+#' )
 #' fr <- p_fuzz_function(lm, test_args)
 p_fuzz_function <- function(fun, .l, check_args = TRUE, progress = interactive()) {
-
   fuzz_asserts(fun, check_args, progress)
   if (is.null(attr(fun, "fun_name"))) {
     fun_name <- deparse(substitute(fun))
@@ -91,8 +139,9 @@ p_fuzz_function <- function(fun, .l, check_args = TRUE, progress = interactive()
     fun_name <- attr(fun, "fun_name")
   }
 
-  if (check_args)
+  if (check_args) {
     assertthat::assert_that(assertthat::has_args(fun, names(.l)))
+  }
 
   # Ensure .l is a named list of named lists
   is_named_ll(.l)
@@ -112,8 +161,9 @@ p_fuzz_function <- function(fun, .l, check_args = TRUE, progress = interactive()
   num_tests <- purrr::reduce(purrr::map_int(.l, length), `*`)
   if (num_tests >= 500000) {
     m <- utils::menu(choices = c("Yes", "No"), title = paste("The supplied tests have", num_tests, "combinations, which may be prohibitively large to calculate. Attempt to proceed?"))
-    if (m != 1)
+    if (m != 1) {
       return(NULL)
+    }
   }
 
   # Generate the list of tests to be done
@@ -121,18 +171,19 @@ p_fuzz_function <- function(fun, .l, check_args = TRUE, progress = interactive()
 
   # After crossing, restore NULL test values
   test_list <- purrr::modify_depth(test_list, 3, function(x) {
-      if (inherits(x, what = "fuzz-null")) {
-        NULL
-      } else {
-        x
-      }
-    })
+    if (inherits(x, what = "fuzz-null")) {
+      NULL
+    } else {
+      x
+    }
+  })
 
   # Create a progress bar, if called for
   if (progress) {
     pb <- progress::progress_bar$new(
       format = " running tests [:bar] :percent eta: :eta",
-      total = length(test_list), clear = FALSE, width = 60)
+      total = length(test_list), clear = FALSE, width = 60
+    )
     pb$tick(0)
   }
 
@@ -150,11 +201,14 @@ p_fuzz_function <- function(fun, .l, check_args = TRUE, progress = interactive()
       # Create a result list with both the results of try_fuzz, as well as a
       # named list pairing argument names with the test names supplied to them
       # for this particular round
-      res <- list(test_result = try_fuzz(fun = fun, fun_name = fun_name,
-                                         all_args = arglist))
+      res <- list(test_result = try_fuzz(
+        fun = fun, fun_name = fun_name,
+        all_args = arglist
+      ))
       res[["test_name"]] <- testnames
       res
-    })
+    }
+  )
 
   structure(fr, class = "fuzz_results")
 }
@@ -172,7 +226,8 @@ p_fuzz_function <- function(fun, .l, check_args = TRUE, progress = interactive()
 fuzz_asserts <- function(fun, check_args, progress) {
   assertthat::assert_that(
     is.function(fun), assertthat::is.flag(check_args),
-    assertthat::is.flag(progress))
+    assertthat::is.flag(progress)
+  )
 }
 
 # Is a list named, and is each of its elements also a named list?
@@ -202,7 +257,6 @@ assertthat::on_failure(is_named) <- function(call, env) {
 
 # Cross a list of named lists
 named_cross_n <- function(ll) {
-
   # Cross the values of the list...
   crossed_values <- purrr::cross(ll)
   # ... and then cross the names
@@ -223,7 +277,6 @@ named_cross_n <- function(ll) {
 # errors along with any values returned by the expression. Returns a list of
 # value, messages, warnings, and errors.
 try_fuzz <- function(fun, fun_name, all_args) {
-
   call <- list(fun = fun_name, args = all_args)
   messages <- NULL
   output <- NULL
@@ -253,12 +306,16 @@ try_fuzz <- function(fun, fun_name, all_args) {
   # expression is done evaluating, messages, warnings, and errors are assigned
   # to the list, which is returned as the final result of try_fuzz
 
-  output <- utils::capture.output({
-    value <- withCallingHandlers(
-      tryCatch(do.call(fun, args = all_args), error = error_handler),
-      message = message_handler,
-      warning = warning_handler
-    )}, type = "output")
+  output <- utils::capture.output(
+    {
+      value <- withCallingHandlers(
+        tryCatch(do.call(fun, args = all_args), error = error_handler),
+        message = message_handler,
+        warning = warning_handler
+      )
+    },
+    type = "output"
+  )
 
   if (length(output) == 0) {
     output <- NULL

--- a/R/fuzzr-package.R
+++ b/R/fuzzr-package.R
@@ -4,5 +4,4 @@
 #' summarizing messages, warnings, errors, and returned values.
 #'
 #' @name fuzzr
-#' @docType package
-NULL
+"_PACKAGE"

--- a/R/outputs.R
+++ b/R/outputs.R
@@ -56,14 +56,13 @@ fuzz_call <- function(fr, index = NULL, ...) {
 # For each result, create a one-row data frame of test names, outputs, messages,
 # warnings, errors, and result classes.
 parse_fuzz_result_concat <- function(fr, delim) {
-
   dfr <- as.data.frame(fr[["test_name"]], stringsAsFactors = FALSE)
 
   elem_collapse <- function(elem) {
     if (is.null(elem)) {
       return(NA_character_)
     } else {
-      paste(elem, collapse = delim)
+      gsub(pattern = "\n", replacement = " ", x = paste(elem, collapse = delim))
     }
   }
 
@@ -77,7 +76,8 @@ parse_fuzz_result_concat <- function(fr, delim) {
   dfr[["result_classes"]] <- ifelse(
     is.null(fr[["test_result"]][["value"]]),
     NA_character_,
-    paste(class(fr[["test_result"]][["value"]]), collapse = delim))
+    paste(class(fr[["test_result"]][["value"]]), collapse = delim)
+  )
 
   dfr
 }
@@ -91,7 +91,6 @@ search_results <- function(fr, index, ...) {
     assertthat::assert_that(assertthat::is.count(index) && index <= length(fr))
     res <- fr[[index]]
   } else {
-
     # if no index, then check based on test name
     .dots <- list(...)
     purrr::walk(.dots, function(p) assertthat::assert_that(assertthat::is.string(p)))
@@ -101,8 +100,9 @@ search_results <- function(fr, index, ...) {
     res <- purrr::detect(fr, function(el) {
       all(purrr::map2_lgl(.dots, names(.dots), function(p, n) grepl(p, x = el[["test_name"]][[n]])))
     })
-    if (length(res) == 0)
+    if (length(res) == 0) {
       warning("Zero matches found.")
+    }
   }
   res
 }

--- a/README.Rmd
+++ b/README.Rmd
@@ -14,21 +14,13 @@ knitr::opts_chunk$set(
 
 # fuzzr
 
-[![Project Status: Active - The project has reached a stable, usable state and is being actively developed.](http://www.repostatus.org/badges/latest/active.svg)](http://www.repostatus.org/#active)
-[![CRAN_Status_Badge](http://www.r-pkg.org/badges/version/fuzzr)](https://cran.r-project.org/package=fuzzr)
-[![Travis-CI Build Status](https://travis-ci.org/mdlincoln/fuzzr.svg?branch=master)](https://travis-ci.org/mdlincoln/fuzzr)
-[![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/mdlincoln/fuzzr?branch=master&svg=true)](https://ci.appveyor.com/project/mdlincoln/fuzzr)
-
-
 fuzzr implements some simple ["fuzz tests"](https://en.wikipedia.org/wiki/Fuzz_testing) for your R functions, passing in a wide array of inputs and returning a report on how your function reacts.
 
 ## Installation
 
 ```{r, eval = FALSE, purl = FALSE}
-install.package("fuzzr")
-
-# Or, for the development version:
-devtools::install_github("mdlincoln/fuzzr")
+# install the development version from here
+devtools::install_github("alan-groot/fuzzr")
 ```
 
 ## Usage
@@ -41,7 +33,6 @@ Several default suites are provided with this package, such as `test_char`, howe
 library(fuzzr)
 str(test_char())
 ```
-
 
 Evaluate a function argument by supplying `fuzz_function` its quoted name, the tests to run, along with any other required static values.
 `fuzz_function` returns a `fuzz_results` object that stores conditions raised by a function (message, warning, or error) along with any value returned by that function.

--- a/README.Rmd
+++ b/README.Rmd
@@ -19,7 +19,7 @@ fuzzr implements some simple ["fuzz tests"](https://en.wikipedia.org/wiki/Fuzz_t
 ## Installation
 
 ```{r, eval = FALSE, purl = FALSE}
-# install the development version from here
+# install the development version from here 
 devtools::install_github("alan-groot/fuzzr")
 ```
 

--- a/README.md
+++ b/README.md
@@ -3,15 +3,6 @@
 
 # fuzzr
 
-[![Project Status: Active - The project has reached a stable, usable
-state and is being actively
-developed.](http://www.repostatus.org/badges/latest/active.svg)](http://www.repostatus.org/#active)
-[![CRAN\_Status\_Badge](http://www.r-pkg.org/badges/version/fuzzr)](https://cran.r-project.org/package=fuzzr)
-[![Travis-CI Build
-Status](https://travis-ci.org/mdlincoln/fuzzr.svg?branch=master)](https://travis-ci.org/mdlincoln/fuzzr)
-[![AppVeyor Build
-Status](https://ci.appveyor.com/api/projects/status/github/mdlincoln/fuzzr?branch=master&svg=true)](https://ci.appveyor.com/project/mdlincoln/fuzzr)
-
 fuzzr implements some simple [“fuzz
 tests”](https://en.wikipedia.org/wiki/Fuzz_testing) for your R
 functions, passing in a wide array of inputs and returning a report on
@@ -20,10 +11,8 @@ how your function reacts.
 ## Installation
 
 ``` r
-install.package("fuzzr")
-
-# Or, for the development version:
-devtools::install_github("mdlincoln/fuzzr")
+# install the development version from here 
+devtools::install_github("alan-groot/fuzzr")
 ```
 
 ## Usage
@@ -52,17 +41,12 @@ Evaluate a function argument by supplying `fuzz_function` its quoted
 name, the tests to run, along with any other required static values.
 `fuzz_function` returns a `fuzz_results` object that stores conditions
 raised by a function (message, warning, or error) along with any value
-returned by that
-function.
+returned by that function.
 
 ``` r
 fuzz_results <- fuzz_function(fun = lm, arg_name = "subset", data = iris, 
                               formula = Sepal.Length ~ Petal.Width + Petal.Length, 
                               tests = test_all())
-#> Warning: `cross_n()` is deprecated; please use `cross()` instead.
-
-#> Warning: `cross_n()` is deprecated; please use `cross()` instead.
-#> Warning: at_depth() is deprecated, please use `modify_depth()` instead
 ```
 
 You can render these results as a data frame:
@@ -72,14 +56,14 @@ fuzz_df <- as.data.frame(fuzz_results)
 knitr::kable(head(fuzz_df))
 ```
 
-| subset                | data | formula                                   | output | messages | warnings | errors           | result\_classes | results\_index |
-| :-------------------- | :--- | :---------------------------------------- | :----- | :------- | :------- | :--------------- | :-------------- | -------------: |
-| char\_empty           | iris | Sepal.Length ~ Petal.Width + Petal.Length | NA     | NA       | NA       | 0 (non-NA) cases | NA              |              1 |
-| char\_single          | iris | Sepal.Length ~ Petal.Width + Petal.Length | NA     | NA       | NA       | 0 (non-NA) cases | NA              |              2 |
-| char\_single\_blank   | iris | Sepal.Length ~ Petal.Width + Petal.Length | NA     | NA       | NA       | 0 (non-NA) cases | NA              |              3 |
-| char\_multiple        | iris | Sepal.Length ~ Petal.Width + Petal.Length | NA     | NA       | NA       | 0 (non-NA) cases | NA              |              4 |
-| char\_multiple\_blank | iris | Sepal.Length ~ Petal.Width + Petal.Length | NA     | NA       | NA       | 0 (non-NA) cases | NA              |              5 |
-| char\_with\_na        | iris | Sepal.Length ~ Petal.Width + Petal.Length | NA     | NA       | NA       | 0 (non-NA) cases | NA              |              6 |
+| subset              | data | formula                                   | output | messages | warnings | errors           | result_classes | results_index |
+|:--------------------|:-----|:------------------------------------------|:-------|:---------|:---------|:-----------------|:---------------|--------------:|
+| char_empty          | iris | Sepal.Length ~ Petal.Width + Petal.Length | NA     | NA       | NA       | 0 (non-NA) cases | NA             |             1 |
+| char_single         | iris | Sepal.Length ~ Petal.Width + Petal.Length | NA     | NA       | NA       | 0 (non-NA) cases | NA             |             2 |
+| char_single_blank   | iris | Sepal.Length ~ Petal.Width + Petal.Length | NA     | NA       | NA       | 0 (non-NA) cases | NA             |             3 |
+| char_multiple       | iris | Sepal.Length ~ Petal.Width + Petal.Length | NA     | NA       | NA       | 0 (non-NA) cases | NA             |             4 |
+| char_multiple_blank | iris | Sepal.Length ~ Petal.Width + Petal.Length | NA     | NA       | NA       | 0 (non-NA) cases | NA             |             5 |
+| char_with_na        | iris | Sepal.Length ~ Petal.Width + Petal.Length | NA     | NA       | NA       | 0 (non-NA) cases | NA             |             6 |
 
 You can also access the value returned by any one test by matching the
 argument tested with its test name:
@@ -95,29 +79,24 @@ coefficients(model)
 
 Specify multiple-argument tests with `p_fuzz_function`, passing a named
 list of arguments and tests to run on each. `p_fuzz_function` will test
-every combination of argument and
-variable.
+every combination of argument and variable.
 
 ``` r
 fuzz_p <- p_fuzz_function(agrep, list(pattern = test_char(), x = test_char()))
-#> Warning: `cross_n()` is deprecated; please use `cross()` instead.
-
-#> Warning: `cross_n()` is deprecated; please use `cross()` instead.
-#> Warning: at_depth() is deprecated, please use `modify_depth()` instead
 length(fuzz_p)
 #> [1] 64
 knitr::kable(head(as.data.frame(fuzz_p)))
 ```
 
-| pattern               | x           | output | messages | warnings                                                                   | errors                                         | result\_classes | results\_index |
-| :-------------------- | :---------- | :----- | :------- | :------------------------------------------------------------------------- | :--------------------------------------------- | :-------------- | -------------: |
-| char\_empty           | char\_empty | NA     | NA       | NA                                                                         | invalid ‘pattern’ argument                     | NA              |              1 |
-| char\_single          | char\_empty | NA     | NA       | NA                                                                         | NA                                             | integer         |              2 |
-| char\_single\_blank   | char\_empty | NA     | NA       | NA                                                                         | ‘pattern’ must be a non-empty character string | NA              |              3 |
-| char\_multiple        | char\_empty | NA     | NA       | argument ‘pattern’ has length \> 1 and only the first element will be used | NA                                             | integer         |              4 |
-| char\_multiple\_blank | char\_empty | NA     | NA       | argument ‘pattern’ has length \> 1 and only the first element will be used | NA                                             | integer         |              5 |
-| char\_with\_na        | char\_empty | NA     | NA       | argument ‘pattern’ has length \> 1 and only the first element will be used | NA                                             | integer         |              6 |
+| pattern             | x          | output | messages | warnings                                                                   | errors                                         | result_classes | results_index |
+|:--------------------|:-----------|:-------|:---------|:---------------------------------------------------------------------------|:-----------------------------------------------|:---------------|--------------:|
+| char_empty          | char_empty | NA     | NA       | NA                                                                         | invalid ‘pattern’ argument                     | NA             |             1 |
+| char_single         | char_empty | NA     | NA       | NA                                                                         | NA                                             | integer        |             2 |
+| char_single_blank   | char_empty | NA     | NA       | NA                                                                         | ‘pattern’ must be a non-empty character string | NA             |             3 |
+| char_multiple       | char_empty | NA     | NA       | argument ‘pattern’ has length \> 1 and only the first element will be used | NA                                             | integer        |             4 |
+| char_multiple_blank | char_empty | NA     | NA       | argument ‘pattern’ has length \> 1 and only the first element will be used | NA                                             | integer        |             5 |
+| char_with_na        | char_empty | NA     | NA       | argument ‘pattern’ has length \> 1 and only the first element will be used | NA                                             | integer        |             6 |
 
------
+------------------------------------------------------------------------
 
 [Matthew Lincoln](http://matthewlincoln.net)

--- a/man/fuzz_function.Rd
+++ b/man/fuzz_function.Rd
@@ -16,7 +16,7 @@ fuzz_function(
 )
 
 fuzz_function_call(
-  quoted_call,
+  function_call,
   tests = test_all(),
   check_args = TRUE,
   progress = interactive()
@@ -41,8 +41,8 @@ pass arguments to a function that accepts arguments via \code{...}.}
 
 \item{progress}{Show a progress bar while running tests?}
 
-\item{quoted_call}{A quoted function call. The parameters that are present
-in this call are fuzz tested separately using \code{tests}.}
+\item{function_call}{A (quoted) function call. The parameters that are
+present in this call are fuzz tested separately using \code{tests}.}
 
 \item{.l}{A named list of tests.}
 }
@@ -72,6 +72,8 @@ fr <- fuzz_function(lm, "formula", data = iris)
 # When evaluating a function that takes ..., set check_args to FALSE
 fr <- fuzz_function(paste, "x", check_args = FALSE)
 fr <- fuzz_function_call(quote(identity(x = 1)))
+fr_unquoted <- fuzz_function_call(quote(identity(x = 1)))
+stopifnot(identical(fr, fr_unquoted))
 knitr::kable(as.data.frame(fr))
 
 fr2 <- fuzz_function_call(quote(identical(x = TRUE, y = FALSE)))
@@ -80,7 +82,7 @@ knitr::kable(as.data.frame(fr2))
 fr3 <- fuzz_function_call(quote(dirname(".")))
 knitr::kable(as.data.frame(fr3))
 
-fr4 <- fuzz_function_call(quote(dirname(path = ".")))
+fr4 <- fuzz_function_call(dirname(path = "."))
 knitr::kable(as.data.frame(fr4))
 
 # Pass tests to multiple arguments via a named list

--- a/man/fuzz_function.Rd
+++ b/man/fuzz_function.Rd
@@ -2,11 +2,25 @@
 % Please edit documentation in R/evaluators.R
 \name{fuzz_function}
 \alias{fuzz_function}
+\alias{fuzz_function_call}
 \alias{p_fuzz_function}
 \title{Fuzz-test a function}
 \usage{
-fuzz_function(fun, arg_name, ..., tests = test_all(), check_args = TRUE,
-  progress = interactive())
+fuzz_function(
+  fun,
+  arg_name,
+  ...,
+  tests = test_all(),
+  check_args = TRUE,
+  progress = interactive()
+)
+
+fuzz_function_call(
+  quoted_call,
+  tests = test_all(),
+  check_args = TRUE,
+  progress = interactive()
+)
 
 p_fuzz_function(fun, .l, check_args = TRUE, progress = interactive())
 }
@@ -26,6 +40,9 @@ defaulting to \code{\link{test_all}}.}
 pass arguments to a function that accepts arguments via \code{...}.}
 
 \item{progress}{Show a progress bar while running tests?}
+
+\item{quoted_call}{A quoted function call. The parameters that are present
+in this call are fuzz tested separately using \code{tests}.}
 
 \item{.l}{A named list of tests.}
 }
@@ -54,13 +71,25 @@ fr <- fuzz_function(lm, "formula", data = iris)
 
 # When evaluating a function that takes ..., set check_args to FALSE
 fr <- fuzz_function(paste, "x", check_args = FALSE)
+fr <- fuzz_function_call(quote(identity(x = 1)))
+knitr::kable(as.data.frame(fr))
+
+fr2 <- fuzz_function_call(quote(identical(x = TRUE, y = FALSE)))
+knitr::kable(as.data.frame(fr2))
+
+fr3 <- fuzz_function_call(quote(dirname(".")))
+knitr::kable(as.data.frame(fr3))
+
+fr4 <- fuzz_function_call(quote(dirname(path = ".")))
+knitr::kable(as.data.frame(fr4))
 
 # Pass tests to multiple arguments via a named list
 test_args <- list(
-   data = test_df(),
-   subset = test_all(),
-   # Specify custom tests with a new named list
-   formula = list(all_vars = Sepal.Length ~ ., one_var = mpg ~ .))
+  data = test_df(),
+  subset = test_all(),
+  # Specify custom tests with a new named list
+  formula = list(all_vars = Sepal.Length ~ ., one_var = mpg ~ .)
+)
 fr <- p_fuzz_function(lm, test_args)
 }
 \seealso{

--- a/man/fuzz_results.Rd
+++ b/man/fuzz_results.Rd
@@ -24,8 +24,8 @@ Access individual fuzz test results
 }
 \section{Functions}{
 \itemize{
-\item \code{fuzz_value}: Access the object returned by the fuzz test
+\item \code{fuzz_value()}: Access the object returned by the fuzz test
 
-\item \code{fuzz_call}: Access the call used for the fuzz test
+\item \code{fuzz_call()}: Access the call used for the fuzz test
+
 }}
-

--- a/man/fuzzr.Rd
+++ b/man/fuzzr.Rd
@@ -2,10 +2,22 @@
 % Please edit documentation in R/fuzzr-package.R
 \docType{package}
 \name{fuzzr}
-\alias{fuzzr}
 \alias{fuzzr-package}
+\alias{fuzzr}
 \title{Fuzz-Test R Functions}
 \description{
 Test function arguments with a wide array of inputs, and produce reports
 summarizing messages, warnings, errors, and returned values.
+}
+\seealso{
+Useful links:
+\itemize{
+  \item \url{https://github.com/mdlincoln/fuzzr}
+  \item Report bugs at \url{https://github.com/mdlincoln/fuzzr/issues}
+}
+
+}
+\author{
+\strong{Maintainer}: Matthew Lincoln \email{matthew.d.lincoln@gmail.com}
+
 }

--- a/man/test_all.Rd
+++ b/man/test_all.Rd
@@ -39,7 +39,7 @@ tests specified below.
 }
 \section{Functions}{
 \itemize{
-\item \code{test_char}: Character vectors \itemize{
+\item \code{test_char()}: Character vectors \itemize{
  \item \code{char_empty}: \code{character(0)}
  \item \code{char_single}: \code{"a"}
  \item \code{char_single_blank}: \code{""}
@@ -50,7 +50,7 @@ tests specified below.
  \item \code{char_all_na}: \code{c(NA_character_, NA_character_, NA_character_)}
 }
 
-\item \code{test_int}: Integer vectors \itemize{
+\item \code{test_int()}: Integer vectors \itemize{
  \item \code{int_empty}: \code{integer(0)}
  \item \code{int_single}: \code{1L}
  \item \code{int_multiple}: \code{1:3}
@@ -59,7 +59,7 @@ tests specified below.
  \item \code{int_all_na}: \code{c(NA_integer_, NA_integer_, NA_integer_)}
 }
 
-\item \code{test_dbl}: Double vectors \itemize{
+\item \code{test_dbl()}: Double vectors \itemize{
  \item \code{dbl_empty}: \code{numeric(0)}
  \item \code{dbl_single}: \code{1.5}
  \item \code{dbl_mutliple}: \code{c(1.5, 2.5, 3.5)}
@@ -68,7 +68,7 @@ tests specified below.
  \item \code{dbl_all_na}: \code{c(NA_real_, NA_real_, NA_real_)}
 }
 
-\item \code{test_lgl}: Logical vectors \itemize{
+\item \code{test_lgl()}: Logical vectors \itemize{
  \item \code{lgl_empty}: \code{logical(0)}
  \item \code{lgl_single}: \code{TRUE}
  \item \code{lgl_mutliple}: \code{c(TRUE, FALSE, FALSE)}
@@ -77,7 +77,7 @@ tests specified below.
  \item \code{lgl_all_na}: \code{c(NA, NA, NA)}
 }
 
-\item \code{test_fctr}: Factor vectors \itemize{
+\item \code{test_fctr()}: Factor vectors \itemize{
  \item \code{fctr_empty}: \code{structure(integer(0), .Label = character(0), class = "factor")}
  \item \code{fctr_single}: \code{structure(1L, .Label = "a", class = "factor")}
  \item \code{fctr_multiple}: \code{structure(1:3, .Label = c("a", "b", "c"), class = "factor")}
@@ -87,7 +87,7 @@ tests specified below.
  \item \code{fctr_all_na}: \code{structure(c(NA_integer_, NA_integer_, NA_integer_), .Label = character(0), class = "factor")}
 }
 
-\item \code{test_date}: Date vectors \itemize{
+\item \code{test_date()}: Date vectors \itemize{
  \item \code{date_single}: \code{as.Date("2001-01-01")}
  \item \code{date_multiple}: \code{as.Date(c("2001-01-01", "1950-05-05"))}
  \item \code{date_with_na}: \code{as.Date(c("2001-01-01", NA, "1950-05-05"))}
@@ -95,13 +95,13 @@ tests specified below.
  \item \code{date_all_na}: \code{as.Date(rep(NA_integer_, 3), origin = "1971-01-01")}
 }
 
-\item \code{test_raw}: Raw vectors \itemize{
+\item \code{test_raw()}: Raw vectors \itemize{
  \item \code{raw_empty}: \code{raw(0)}
  \item \code{raw_char}: \code{as.raw(0x62)},
  \item \code{raw_na}: \code{charToRaw(NA_character_)}
 }
 
-\item \code{test_df}: Data frames \itemize{
+\item \code{test_df()}: Data frames \itemize{
   \item \code{df_complete}: \code{datasets::iris}
   \item \code{df_empty}: \code{data.frame(NULL)}
   \item \code{df_one_row}: \code{datasets::iris[1, ]}
@@ -109,8 +109,8 @@ tests specified below.
   \item \code{df_with_na}: \code{iris} with several NAs added to each column.
 }
 
-\item \code{test_null}: Null value \itemize{
+\item \code{test_null()}: Null value \itemize{
  \item \code{null_value}: \code{NULL}
 }
-}}
 
+}}

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,3 +1,11 @@
+# This file is part of the standard setup for testthat.
+# It is recommended that you do not modify it.
+#
+# Where should you do additional test configuration?
+# Learn more about the roles of various files in:
+# * https://r-pkgs.org/testing-design.html#sec-tests-files-overview
+# * https://testthat.r-lib.org/articles/special-files.html
+
 library(testthat)
 library(fuzzr)
 

--- a/tests/testthat/_snaps/evaluators.md
+++ b/tests/testthat/_snaps/evaluators.md
@@ -1,0 +1,502 @@
+# snapshot tests from example
+
+    Code
+      as.data.frame(fr)
+    Output
+                           x output messages warnings errors result_classes
+      1           char_empty   <NA>     <NA>     <NA>   <NA>      character
+      2          char_single   <NA>     <NA>     <NA>   <NA>      character
+      3    char_single_blank   <NA>     <NA>     <NA>   <NA>      character
+      4        char_multiple   <NA>     <NA>     <NA>   <NA>      character
+      5  char_multiple_blank   <NA>     <NA>     <NA>   <NA>      character
+      6         char_with_na   <NA>     <NA>     <NA>   <NA>      character
+      7       char_single_na   <NA>     <NA>     <NA>   <NA>      character
+      8          char_all_na   <NA>     <NA>     <NA>   <NA>      character
+      9            int_empty   <NA>     <NA>     <NA>   <NA>        integer
+      10          int_single   <NA>     <NA>     <NA>   <NA>        integer
+      11        int_multiple   <NA>     <NA>     <NA>   <NA>        integer
+      12         int_with_na   <NA>     <NA>     <NA>   <NA>        integer
+      13       int_single_na   <NA>     <NA>     <NA>   <NA>        integer
+      14          int_all_na   <NA>     <NA>     <NA>   <NA>        integer
+      15           dbl_empty   <NA>     <NA>     <NA>   <NA>        numeric
+      16          dbl_single   <NA>     <NA>     <NA>   <NA>        numeric
+      17        dbl_mutliple   <NA>     <NA>     <NA>   <NA>        numeric
+      18         dbl_with_na   <NA>     <NA>     <NA>   <NA>        numeric
+      19       dbl_single_na   <NA>     <NA>     <NA>   <NA>        numeric
+      20          dbl_all_na   <NA>     <NA>     <NA>   <NA>        numeric
+      21          fctr_empty   <NA>     <NA>     <NA>   <NA>         factor
+      22         fctr_single   <NA>     <NA>     <NA>   <NA>         factor
+      23       fctr_multiple   <NA>     <NA>     <NA>   <NA>         factor
+      24        fctr_with_na   <NA>     <NA>     <NA>   <NA>         factor
+      25 fctr_missing_levels   <NA>     <NA>     <NA>   <NA>         factor
+      26      fctr_single_na   <NA>     <NA>     <NA>   <NA>         factor
+      27         fctr_all_na   <NA>     <NA>     <NA>   <NA>         factor
+      28           lgl_empty   <NA>     <NA>     <NA>   <NA>        logical
+      29          lgl_single   <NA>     <NA>     <NA>   <NA>        logical
+      30        lgl_mutliple   <NA>     <NA>     <NA>   <NA>        logical
+      31         lgl_with_na   <NA>     <NA>     <NA>   <NA>        logical
+      32       lgl_single_na   <NA>     <NA>     <NA>   <NA>        logical
+      33          lgl_all_na   <NA>     <NA>     <NA>   <NA>        logical
+      34         date_single   <NA>     <NA>     <NA>   <NA>           Date
+      35       date_multiple   <NA>     <NA>     <NA>   <NA>           Date
+      36        date_with_na   <NA>     <NA>     <NA>   <NA>           Date
+      37      date_single_na   <NA>     <NA>     <NA>   <NA>           Date
+      38         date_all_na   <NA>     <NA>     <NA>   <NA>           Date
+      39           raw_empty   <NA>     <NA>     <NA>   <NA>            raw
+      40            raw_char   <NA>     <NA>     <NA>   <NA>            raw
+      41              raw_na   <NA>     <NA>     <NA>   <NA>            raw
+      42         df_complete   <NA>     <NA>     <NA>   <NA>     data.frame
+      43            df_empty   <NA>     <NA>     <NA>   <NA>     data.frame
+      44          df_one_row   <NA>     <NA>     <NA>   <NA>     data.frame
+      45          df_one_col   <NA>     <NA>     <NA>   <NA>        numeric
+      46          df_with_na   <NA>     <NA>     <NA>   <NA>     data.frame
+      47          null_value   <NA>     <NA>     <NA>   <NA>           <NA>
+         results_index
+      1              1
+      2              2
+      3              3
+      4              4
+      5              5
+      6              6
+      7              7
+      8              8
+      9              9
+      10            10
+      11            11
+      12            12
+      13            13
+      14            14
+      15            15
+      16            16
+      17            17
+      18            18
+      19            19
+      20            20
+      21            21
+      22            22
+      23            23
+      24            24
+      25            25
+      26            26
+      27            27
+      28            28
+      29            29
+      30            30
+      31            31
+      32            32
+      33            33
+      34            34
+      35            35
+      36            36
+      37            37
+      38            38
+      39            39
+      40            40
+      41            41
+      42            42
+      43            43
+      44            44
+      45            45
+      46            46
+      47            47
+
+---
+
+    Code
+      as.data.frame(fr2)
+    Output
+                           x                   y output messages warnings errors
+      1           char_empty                   y   <NA>     <NA>     <NA>   <NA>
+      2          char_single                   y   <NA>     <NA>     <NA>   <NA>
+      3    char_single_blank                   y   <NA>     <NA>     <NA>   <NA>
+      4        char_multiple                   y   <NA>     <NA>     <NA>   <NA>
+      5  char_multiple_blank                   y   <NA>     <NA>     <NA>   <NA>
+      6         char_with_na                   y   <NA>     <NA>     <NA>   <NA>
+      7       char_single_na                   y   <NA>     <NA>     <NA>   <NA>
+      8          char_all_na                   y   <NA>     <NA>     <NA>   <NA>
+      9            int_empty                   y   <NA>     <NA>     <NA>   <NA>
+      10          int_single                   y   <NA>     <NA>     <NA>   <NA>
+      11        int_multiple                   y   <NA>     <NA>     <NA>   <NA>
+      12         int_with_na                   y   <NA>     <NA>     <NA>   <NA>
+      13       int_single_na                   y   <NA>     <NA>     <NA>   <NA>
+      14          int_all_na                   y   <NA>     <NA>     <NA>   <NA>
+      15           dbl_empty                   y   <NA>     <NA>     <NA>   <NA>
+      16          dbl_single                   y   <NA>     <NA>     <NA>   <NA>
+      17        dbl_mutliple                   y   <NA>     <NA>     <NA>   <NA>
+      18         dbl_with_na                   y   <NA>     <NA>     <NA>   <NA>
+      19       dbl_single_na                   y   <NA>     <NA>     <NA>   <NA>
+      20          dbl_all_na                   y   <NA>     <NA>     <NA>   <NA>
+      21          fctr_empty                   y   <NA>     <NA>     <NA>   <NA>
+      22         fctr_single                   y   <NA>     <NA>     <NA>   <NA>
+      23       fctr_multiple                   y   <NA>     <NA>     <NA>   <NA>
+      24        fctr_with_na                   y   <NA>     <NA>     <NA>   <NA>
+      25 fctr_missing_levels                   y   <NA>     <NA>     <NA>   <NA>
+      26      fctr_single_na                   y   <NA>     <NA>     <NA>   <NA>
+      27         fctr_all_na                   y   <NA>     <NA>     <NA>   <NA>
+      28           lgl_empty                   y   <NA>     <NA>     <NA>   <NA>
+      29          lgl_single                   y   <NA>     <NA>     <NA>   <NA>
+      30        lgl_mutliple                   y   <NA>     <NA>     <NA>   <NA>
+      31         lgl_with_na                   y   <NA>     <NA>     <NA>   <NA>
+      32       lgl_single_na                   y   <NA>     <NA>     <NA>   <NA>
+      33          lgl_all_na                   y   <NA>     <NA>     <NA>   <NA>
+      34         date_single                   y   <NA>     <NA>     <NA>   <NA>
+      35       date_multiple                   y   <NA>     <NA>     <NA>   <NA>
+      36        date_with_na                   y   <NA>     <NA>     <NA>   <NA>
+      37      date_single_na                   y   <NA>     <NA>     <NA>   <NA>
+      38         date_all_na                   y   <NA>     <NA>     <NA>   <NA>
+      39           raw_empty                   y   <NA>     <NA>     <NA>   <NA>
+      40            raw_char                   y   <NA>     <NA>     <NA>   <NA>
+      41              raw_na                   y   <NA>     <NA>     <NA>   <NA>
+      42         df_complete                   y   <NA>     <NA>     <NA>   <NA>
+      43            df_empty                   y   <NA>     <NA>     <NA>   <NA>
+      44          df_one_row                   y   <NA>     <NA>     <NA>   <NA>
+      45          df_one_col                   y   <NA>     <NA>     <NA>   <NA>
+      46          df_with_na                   y   <NA>     <NA>     <NA>   <NA>
+      47          null_value                   y   <NA>     <NA>     <NA>   <NA>
+      48                   x          char_empty   <NA>     <NA>     <NA>   <NA>
+      49                   x         char_single   <NA>     <NA>     <NA>   <NA>
+      50                   x   char_single_blank   <NA>     <NA>     <NA>   <NA>
+      51                   x       char_multiple   <NA>     <NA>     <NA>   <NA>
+      52                   x char_multiple_blank   <NA>     <NA>     <NA>   <NA>
+      53                   x        char_with_na   <NA>     <NA>     <NA>   <NA>
+      54                   x      char_single_na   <NA>     <NA>     <NA>   <NA>
+      55                   x         char_all_na   <NA>     <NA>     <NA>   <NA>
+      56                   x           int_empty   <NA>     <NA>     <NA>   <NA>
+      57                   x          int_single   <NA>     <NA>     <NA>   <NA>
+      58                   x        int_multiple   <NA>     <NA>     <NA>   <NA>
+      59                   x         int_with_na   <NA>     <NA>     <NA>   <NA>
+      60                   x       int_single_na   <NA>     <NA>     <NA>   <NA>
+      61                   x          int_all_na   <NA>     <NA>     <NA>   <NA>
+      62                   x           dbl_empty   <NA>     <NA>     <NA>   <NA>
+      63                   x          dbl_single   <NA>     <NA>     <NA>   <NA>
+      64                   x        dbl_mutliple   <NA>     <NA>     <NA>   <NA>
+      65                   x         dbl_with_na   <NA>     <NA>     <NA>   <NA>
+      66                   x       dbl_single_na   <NA>     <NA>     <NA>   <NA>
+      67                   x          dbl_all_na   <NA>     <NA>     <NA>   <NA>
+      68                   x          fctr_empty   <NA>     <NA>     <NA>   <NA>
+      69                   x         fctr_single   <NA>     <NA>     <NA>   <NA>
+      70                   x       fctr_multiple   <NA>     <NA>     <NA>   <NA>
+      71                   x        fctr_with_na   <NA>     <NA>     <NA>   <NA>
+      72                   x fctr_missing_levels   <NA>     <NA>     <NA>   <NA>
+      73                   x      fctr_single_na   <NA>     <NA>     <NA>   <NA>
+      74                   x         fctr_all_na   <NA>     <NA>     <NA>   <NA>
+      75                   x           lgl_empty   <NA>     <NA>     <NA>   <NA>
+      76                   x          lgl_single   <NA>     <NA>     <NA>   <NA>
+      77                   x        lgl_mutliple   <NA>     <NA>     <NA>   <NA>
+      78                   x         lgl_with_na   <NA>     <NA>     <NA>   <NA>
+      79                   x       lgl_single_na   <NA>     <NA>     <NA>   <NA>
+      80                   x          lgl_all_na   <NA>     <NA>     <NA>   <NA>
+      81                   x         date_single   <NA>     <NA>     <NA>   <NA>
+      82                   x       date_multiple   <NA>     <NA>     <NA>   <NA>
+      83                   x        date_with_na   <NA>     <NA>     <NA>   <NA>
+      84                   x      date_single_na   <NA>     <NA>     <NA>   <NA>
+      85                   x         date_all_na   <NA>     <NA>     <NA>   <NA>
+      86                   x           raw_empty   <NA>     <NA>     <NA>   <NA>
+      87                   x            raw_char   <NA>     <NA>     <NA>   <NA>
+      88                   x              raw_na   <NA>     <NA>     <NA>   <NA>
+      89                   x         df_complete   <NA>     <NA>     <NA>   <NA>
+      90                   x            df_empty   <NA>     <NA>     <NA>   <NA>
+      91                   x          df_one_row   <NA>     <NA>     <NA>   <NA>
+      92                   x          df_one_col   <NA>     <NA>     <NA>   <NA>
+      93                   x          df_with_na   <NA>     <NA>     <NA>   <NA>
+      94                   x          null_value   <NA>     <NA>     <NA>   <NA>
+         result_classes results_index
+      1         logical             1
+      2         logical             2
+      3         logical             3
+      4         logical             4
+      5         logical             5
+      6         logical             6
+      7         logical             7
+      8         logical             8
+      9         logical             9
+      10        logical            10
+      11        logical            11
+      12        logical            12
+      13        logical            13
+      14        logical            14
+      15        logical            15
+      16        logical            16
+      17        logical            17
+      18        logical            18
+      19        logical            19
+      20        logical            20
+      21        logical            21
+      22        logical            22
+      23        logical            23
+      24        logical            24
+      25        logical            25
+      26        logical            26
+      27        logical            27
+      28        logical            28
+      29        logical            29
+      30        logical            30
+      31        logical            31
+      32        logical            32
+      33        logical            33
+      34        logical            34
+      35        logical            35
+      36        logical            36
+      37        logical            37
+      38        logical            38
+      39        logical            39
+      40        logical            40
+      41        logical            41
+      42        logical            42
+      43        logical            43
+      44        logical            44
+      45        logical            45
+      46        logical            46
+      47        logical            47
+      48        logical            48
+      49        logical            49
+      50        logical            50
+      51        logical            51
+      52        logical            52
+      53        logical            53
+      54        logical            54
+      55        logical            55
+      56        logical            56
+      57        logical            57
+      58        logical            58
+      59        logical            59
+      60        logical            60
+      61        logical            61
+      62        logical            62
+      63        logical            63
+      64        logical            64
+      65        logical            65
+      66        logical            66
+      67        logical            67
+      68        logical            68
+      69        logical            69
+      70        logical            70
+      71        logical            71
+      72        logical            72
+      73        logical            73
+      74        logical            74
+      75        logical            75
+      76        logical            76
+      77        logical            77
+      78        logical            78
+      79        logical            79
+      80        logical            80
+      81        logical            81
+      82        logical            82
+      83        logical            83
+      84        logical            84
+      85        logical            85
+      86        logical            86
+      87        logical            87
+      88        logical            88
+      89        logical            89
+      90        logical            90
+      91        logical            91
+      92        logical            92
+      93        logical            93
+      94        logical            94
+
+---
+
+    Code
+      as.data.frame(fr3)
+    Output
+                        path output messages warnings
+      1           char_empty   <NA>     <NA>     <NA>
+      2          char_single   <NA>     <NA>     <NA>
+      3    char_single_blank   <NA>     <NA>     <NA>
+      4        char_multiple   <NA>     <NA>     <NA>
+      5  char_multiple_blank   <NA>     <NA>     <NA>
+      6         char_with_na   <NA>     <NA>     <NA>
+      7       char_single_na   <NA>     <NA>     <NA>
+      8          char_all_na   <NA>     <NA>     <NA>
+      9            int_empty   <NA>     <NA>     <NA>
+      10          int_single   <NA>     <NA>     <NA>
+      11        int_multiple   <NA>     <NA>     <NA>
+      12         int_with_na   <NA>     <NA>     <NA>
+      13       int_single_na   <NA>     <NA>     <NA>
+      14          int_all_na   <NA>     <NA>     <NA>
+      15           dbl_empty   <NA>     <NA>     <NA>
+      16          dbl_single   <NA>     <NA>     <NA>
+      17        dbl_mutliple   <NA>     <NA>     <NA>
+      18         dbl_with_na   <NA>     <NA>     <NA>
+      19       dbl_single_na   <NA>     <NA>     <NA>
+      20          dbl_all_na   <NA>     <NA>     <NA>
+      21          fctr_empty   <NA>     <NA>     <NA>
+      22         fctr_single   <NA>     <NA>     <NA>
+      23       fctr_multiple   <NA>     <NA>     <NA>
+      24        fctr_with_na   <NA>     <NA>     <NA>
+      25 fctr_missing_levels   <NA>     <NA>     <NA>
+      26      fctr_single_na   <NA>     <NA>     <NA>
+      27         fctr_all_na   <NA>     <NA>     <NA>
+      28           lgl_empty   <NA>     <NA>     <NA>
+      29          lgl_single   <NA>     <NA>     <NA>
+      30        lgl_mutliple   <NA>     <NA>     <NA>
+      31         lgl_with_na   <NA>     <NA>     <NA>
+      32       lgl_single_na   <NA>     <NA>     <NA>
+      33          lgl_all_na   <NA>     <NA>     <NA>
+      34         date_single   <NA>     <NA>     <NA>
+      35       date_multiple   <NA>     <NA>     <NA>
+      36        date_with_na   <NA>     <NA>     <NA>
+      37      date_single_na   <NA>     <NA>     <NA>
+      38         date_all_na   <NA>     <NA>     <NA>
+      39           raw_empty   <NA>     <NA>     <NA>
+      40            raw_char   <NA>     <NA>     <NA>
+      41              raw_na   <NA>     <NA>     <NA>
+      42         df_complete   <NA>     <NA>     <NA>
+      43            df_empty   <NA>     <NA>     <NA>
+      44          df_one_row   <NA>     <NA>     <NA>
+      45          df_one_col   <NA>     <NA>     <NA>
+      46          df_with_na   <NA>     <NA>     <NA>
+      47          null_value   <NA>     <NA>     <NA>
+                                       errors result_classes results_index
+      1                                  <NA>      character             1
+      2                                  <NA>      character             2
+      3                                  <NA>      character             3
+      4                                  <NA>      character             4
+      5                                  <NA>      character             5
+      6                                  <NA>      character             6
+      7                                  <NA>      character             7
+      8                                  <NA>      character             8
+      9  a character vector argument expected           <NA>             9
+      10 a character vector argument expected           <NA>            10
+      11 a character vector argument expected           <NA>            11
+      12 a character vector argument expected           <NA>            12
+      13 a character vector argument expected           <NA>            13
+      14 a character vector argument expected           <NA>            14
+      15 a character vector argument expected           <NA>            15
+      16 a character vector argument expected           <NA>            16
+      17 a character vector argument expected           <NA>            17
+      18 a character vector argument expected           <NA>            18
+      19 a character vector argument expected           <NA>            19
+      20 a character vector argument expected           <NA>            20
+      21 a character vector argument expected           <NA>            21
+      22 a character vector argument expected           <NA>            22
+      23 a character vector argument expected           <NA>            23
+      24 a character vector argument expected           <NA>            24
+      25 a character vector argument expected           <NA>            25
+      26 a character vector argument expected           <NA>            26
+      27 a character vector argument expected           <NA>            27
+      28 a character vector argument expected           <NA>            28
+      29 a character vector argument expected           <NA>            29
+      30 a character vector argument expected           <NA>            30
+      31 a character vector argument expected           <NA>            31
+      32 a character vector argument expected           <NA>            32
+      33 a character vector argument expected           <NA>            33
+      34 a character vector argument expected           <NA>            34
+      35 a character vector argument expected           <NA>            35
+      36 a character vector argument expected           <NA>            36
+      37 a character vector argument expected           <NA>            37
+      38 a character vector argument expected           <NA>            38
+      39 a character vector argument expected           <NA>            39
+      40 a character vector argument expected           <NA>            40
+      41 a character vector argument expected           <NA>            41
+      42 a character vector argument expected           <NA>            42
+      43 a character vector argument expected           <NA>            43
+      44 a character vector argument expected           <NA>            44
+      45 a character vector argument expected           <NA>            45
+      46 a character vector argument expected           <NA>            46
+      47 a character vector argument expected           <NA>            47
+
+---
+
+    Code
+      as.data.frame(fr4)
+    Output
+                        path output messages warnings
+      1           char_empty   <NA>     <NA>     <NA>
+      2          char_single   <NA>     <NA>     <NA>
+      3    char_single_blank   <NA>     <NA>     <NA>
+      4        char_multiple   <NA>     <NA>     <NA>
+      5  char_multiple_blank   <NA>     <NA>     <NA>
+      6         char_with_na   <NA>     <NA>     <NA>
+      7       char_single_na   <NA>     <NA>     <NA>
+      8          char_all_na   <NA>     <NA>     <NA>
+      9            int_empty   <NA>     <NA>     <NA>
+      10          int_single   <NA>     <NA>     <NA>
+      11        int_multiple   <NA>     <NA>     <NA>
+      12         int_with_na   <NA>     <NA>     <NA>
+      13       int_single_na   <NA>     <NA>     <NA>
+      14          int_all_na   <NA>     <NA>     <NA>
+      15           dbl_empty   <NA>     <NA>     <NA>
+      16          dbl_single   <NA>     <NA>     <NA>
+      17        dbl_mutliple   <NA>     <NA>     <NA>
+      18         dbl_with_na   <NA>     <NA>     <NA>
+      19       dbl_single_na   <NA>     <NA>     <NA>
+      20          dbl_all_na   <NA>     <NA>     <NA>
+      21          fctr_empty   <NA>     <NA>     <NA>
+      22         fctr_single   <NA>     <NA>     <NA>
+      23       fctr_multiple   <NA>     <NA>     <NA>
+      24        fctr_with_na   <NA>     <NA>     <NA>
+      25 fctr_missing_levels   <NA>     <NA>     <NA>
+      26      fctr_single_na   <NA>     <NA>     <NA>
+      27         fctr_all_na   <NA>     <NA>     <NA>
+      28           lgl_empty   <NA>     <NA>     <NA>
+      29          lgl_single   <NA>     <NA>     <NA>
+      30        lgl_mutliple   <NA>     <NA>     <NA>
+      31         lgl_with_na   <NA>     <NA>     <NA>
+      32       lgl_single_na   <NA>     <NA>     <NA>
+      33          lgl_all_na   <NA>     <NA>     <NA>
+      34         date_single   <NA>     <NA>     <NA>
+      35       date_multiple   <NA>     <NA>     <NA>
+      36        date_with_na   <NA>     <NA>     <NA>
+      37      date_single_na   <NA>     <NA>     <NA>
+      38         date_all_na   <NA>     <NA>     <NA>
+      39           raw_empty   <NA>     <NA>     <NA>
+      40            raw_char   <NA>     <NA>     <NA>
+      41              raw_na   <NA>     <NA>     <NA>
+      42         df_complete   <NA>     <NA>     <NA>
+      43            df_empty   <NA>     <NA>     <NA>
+      44          df_one_row   <NA>     <NA>     <NA>
+      45          df_one_col   <NA>     <NA>     <NA>
+      46          df_with_na   <NA>     <NA>     <NA>
+      47          null_value   <NA>     <NA>     <NA>
+                                       errors result_classes results_index
+      1                                  <NA>      character             1
+      2                                  <NA>      character             2
+      3                                  <NA>      character             3
+      4                                  <NA>      character             4
+      5                                  <NA>      character             5
+      6                                  <NA>      character             6
+      7                                  <NA>      character             7
+      8                                  <NA>      character             8
+      9  a character vector argument expected           <NA>             9
+      10 a character vector argument expected           <NA>            10
+      11 a character vector argument expected           <NA>            11
+      12 a character vector argument expected           <NA>            12
+      13 a character vector argument expected           <NA>            13
+      14 a character vector argument expected           <NA>            14
+      15 a character vector argument expected           <NA>            15
+      16 a character vector argument expected           <NA>            16
+      17 a character vector argument expected           <NA>            17
+      18 a character vector argument expected           <NA>            18
+      19 a character vector argument expected           <NA>            19
+      20 a character vector argument expected           <NA>            20
+      21 a character vector argument expected           <NA>            21
+      22 a character vector argument expected           <NA>            22
+      23 a character vector argument expected           <NA>            23
+      24 a character vector argument expected           <NA>            24
+      25 a character vector argument expected           <NA>            25
+      26 a character vector argument expected           <NA>            26
+      27 a character vector argument expected           <NA>            27
+      28 a character vector argument expected           <NA>            28
+      29 a character vector argument expected           <NA>            29
+      30 a character vector argument expected           <NA>            30
+      31 a character vector argument expected           <NA>            31
+      32 a character vector argument expected           <NA>            32
+      33 a character vector argument expected           <NA>            33
+      34 a character vector argument expected           <NA>            34
+      35 a character vector argument expected           <NA>            35
+      36 a character vector argument expected           <NA>            36
+      37 a character vector argument expected           <NA>            37
+      38 a character vector argument expected           <NA>            38
+      39 a character vector argument expected           <NA>            39
+      40 a character vector argument expected           <NA>            40
+      41 a character vector argument expected           <NA>            41
+      42 a character vector argument expected           <NA>            42
+      43 a character vector argument expected           <NA>            43
+      44 a character vector argument expected           <NA>            44
+      45 a character vector argument expected           <NA>            45
+      46 a character vector argument expected           <NA>            46
+      47 a character vector argument expected           <NA>            47
+

--- a/tests/testthat/test-evaluators.R
+++ b/tests/testthat/test-evaluators.R
@@ -10,4 +10,7 @@ test_that("snapshot tests from example", {
   
   fr4 <- fuzz_function_call(quote(dirname(path = ".")))
   expect_snapshot(as.data.frame(fr4))
+
+  fr5 <- fuzz_function_call(dirname(path = "."))
+  expect_identical(fr5, fr4)
 })

--- a/tests/testthat/test-evaluators.R
+++ b/tests/testthat/test-evaluators.R
@@ -1,0 +1,13 @@
+test_that("snapshot tests from example", {
+  fr <- fuzz_function_call(quote(identity(x = 1)))
+  expect_snapshot(as.data.frame(fr))
+  
+  fr2 <- fuzz_function_call(quote(identical(x = TRUE, y = FALSE)))
+  expect_snapshot(as.data.frame(fr2))
+  
+  fr3 <- fuzz_function_call(quote(dirname(".")))
+  expect_snapshot(as.data.frame(fr3))
+  
+  fr4 <- fuzz_function_call(quote(dirname(path = ".")))
+  expect_snapshot(as.data.frame(fr4))
+})


### PR DESCRIPTION
* `fuzz_function_call()` no longer requires the function call to be surrounded by `quote()`.
* the `quoted_call` argument was renamed to `function_call`. Both quoted and unquoted calls are handled properly.